### PR TITLE
disable vrik locomotion while flying

### DIFF
--- a/ml_amt/MotionTweaker.cs
+++ b/ml_amt/MotionTweaker.cs
@@ -1,4 +1,4 @@
-﻿using ABI_RC.Core.Networking.IO.UserGeneratedContent;
+using ABI_RC.Core.Networking.IO.UserGeneratedContent;
 using ABI_RC.Core.Player;
 using ABI_RC.Systems.MovementSystem;
 using System.Collections.Generic;
@@ -70,7 +70,8 @@ namespace ml_amt
                 {
                     float immobileWeight = (PlayerSetup.Instance._movementSystem.movementVector.magnitude <= Mathf.Epsilon) ? 1f : 0f;
                     float standingWeight = m_standing ? 1f : 0f;
-                    m_locomotionWeight = standingWeight * immobileWeight;
+                    float flyingWeight = PlayerSetup.Instance._movementSystem.flying ? 0f : 1f;
+                    m_locomotionWeight = standingWeight * immobileWeight * flyingWeight;
                     m_vrIk.solver.locomotion.weight = m_locomotionWeight;
 
                     // Immediately update avatar position if locomotion is off


### PR DESCRIPTION
Disables VRIK loco while flying. Base game flight for some reason still has footstep on.

An interesting quirk about this mod is that it allows you to enter crouch/prone while flying with VR. Most likely an oversight that I wish was base-game.